### PR TITLE
fixed iou calculation mistake, this will fix the Nan loss issue

### DIFF
--- a/yolo/model/loss.py
+++ b/yolo/model/loss.py
@@ -77,9 +77,8 @@ def bbox_iou(bbox1, bbox2, xyxy=False, giou=False, diou=False, ciou=False, epsil
         b2y1, b2y2 = bbox2[..., 1] - bbox2[..., 3] / 2, bbox2[..., 1] + bbox2[..., 3] / 2
 
     # intersection area
-    inter = (tf.minimum(b1x2, b2x2) - tf.maximum(b1x1, b2x1)) * \
-            (tf.minimum(b1y2, b2y2) - tf.maximum(b1y1, b2y1))
-    inter = tf.where(inter > 0, inter, tf.zeros_like(inter))
+    inter = tf.maximum(tf.minimum(b1x2, b2x2) - tf.maximum(b1x1, b2x1), 0) * \
+            tf.maximum(tf.minimum(b1y2, b2y2) - tf.maximum(b1y1, b2y1), 0)
 
     # union area
     w1, h1 = b1x2 - b1x1 + epsilon, b1y2 - b1y1 + epsilon


### PR DESCRIPTION
This PR addresses a mistake made in the iou calculation.  The original method of calculating intersection will lead to incorrect iou value.  

For example, considering two boxes that do not overlap each other in `[x1, y1, x2, y2]` format: `[0, 0, 10, 10]` and `[20, 20, 30, 30]`: using the original formula: `inter = (min(10, 30) - max(0, 20)) * (min(10, 30) - max(0, 20)) = 100`. However, it's clear that the intersection of `[0, 0, 10, 10]` and `[20, 20, 30, 30]` should be 0.

I believe the loss implementation uses the official Pytorch implementation as reference, from the intersection calculation of [official implementation](https://github.com/ultralytics/yolov5/blob/master/utils/general.py#L410-L412), you can see the correct way of calculating intersection:
```
inter = (torch.min(b1_x2, b2_x2) - torch.max(b1_x1, b2_x1)).clamp(0) * \
            (torch.min(b1_y2, b2_y2) - torch.max(b1_y1, b2_y1)).clamp(0)
```

This PR will make sure intersection calculation is the same as the official implementation, and will fix the #2 