### PR TITLE
prepare_data.py doesn't contain parse_xml method

### DIFF
--- a/yolo/dataset/prepare_data.py
+++ b/yolo/dataset/prepare_data.py
@@ -148,7 +148,7 @@ class VOCPrepare(object):
     def get_objects(self):
         all_objects = []
         for xml in self.xml_files:
-            objects = self.parser.parse_xml(xml, self.data_dir, self.class_map, return_img=False)
+            objects = self.parser.parse(xml, self.data_dir, self.class_map, return_img=False)
             if objects is not None:
                 all_objects.append(objects)
         return all_objects


### PR DESCRIPTION
In the `prepare_data.py` line 151 we are calling `VOCParser.parse_xml` but there is no method `parse_xml` in the `VOCParser` class. I think it should be called the method `parse` in `VOCParser` class should be called here. I checked it by replacing with `parse` method and its working good. 